### PR TITLE
Fix URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Scratux is built-in different languages and is always based on the latest stable
 
 Download/Install
 ----
-[Download latest release from the official page](https://scratux.org/#download)
+[Download latest release from the official page](https://scratux-revived.github.io/#download)
 
 Screenshots
 ----


### PR DESCRIPTION
The URL for download / install was still pointing to the old page, not the new one.